### PR TITLE
fix(core): fixing a vulnerability in newtonsoft nuget (#39)

### DIFF
--- a/Geo.NET.sln
+++ b/Geo.NET.sln
@@ -10,7 +10,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionIt
 		README.md = README.md
 		src\Source.props = src\Source.props
 		stylecop.json = stylecop.json
-		tests\Tests.with.xUnit.props = tests\Tests.with.xUnit.props
+		test\Tests.with.xUnit.props = test\Tests.with.xUnit.props
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{8F3BA9BC-542C-450C-96C9-F0D72FECC930}"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The support for this project includes:
 	 - Open API
 		 - [Geocoding](https://developer.mapquest.com/documentation/open/geocoding-api/)
 		 - [Reverse Geocoding](https://developer.mapquest.com/documentation/open/geocoding-api/)
-	 - Lisenced API
+	 - Licensed API
 		 - [Geocoding](https://developer.mapquest.com/documentation/geocoding-api/address/get/)
 		 - [Reverse Geocoding](https://developer.mapquest.com/documentation/geocoding-api/reverse/get/)
 

--- a/src/Geo.Core/Geo.Core.csproj
+++ b/src/Geo.Core/Geo.Core.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
A vulnerability was found in newtonsoft packages, read https://github.com/advisories/GHSA-5crp-9r3c-p9vr. Updating the package to avoid this