### PR TITLE
Don't pull in entire ASP.NET framework

### DIFF
--- a/src/Source.props
+++ b/src/Source.props
@@ -16,12 +16,7 @@
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.1'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
I've attempted to use this library in a background application responsible for processing GPS coordinates. Our application being a backend processor is NOT an AspNet application and that framework is not available in the production environment on which our application runs. The problem is, Geo.NET contains a hard reference to the AspNet framework. This means, simply adding a reference to Geo.NET causes the production services to fail to start. (Errors about missing AspNet framework)

I've poked through a bit, and it seems the only usage is "QueryString" class for building request Uris. This class exists in the Http.Abstractions package which is perfectly fine to reference even in non aspnet applications. I've not dug too deeply but I can't seem to see any good reason to be pulling in this entire framework. I've made a temporary one off build of this library encompassing the below changes and it is working great for us. Hopefully they can be merged into the official package. 