### PR TITLE
fix(here): Adding missing enum values on ResultType

### DIFF
--- a/src/Geo.Here/Enums/ResultType.cs
+++ b/src/Geo.Here/Enums/ResultType.cs
@@ -47,5 +47,29 @@ namespace Geo.Here.Enums
         /// </summary>
         [EnumMember(Value = "place")]
         Place,
+
+        /// <summary>
+        /// Indicates the intersection of multiple streets.
+        /// </summary>
+        [EnumMember(Value = "intersection")]
+        Intersection,
+
+        /// <summary>
+        /// Indicates a postal code result.
+        /// </summary>
+        [EnumMember(Value = "postalCodePoint")]
+        PostalCodePoint,
+
+        /// <summary>
+        /// Indicates a chain query response.
+        /// </summary>
+        [EnumMember(Value = "chainQuery")]
+        ChainQuery,
+
+        /// <summary>
+        /// Indicates a category response.
+        /// </summary>
+        [EnumMember(Value = "categoryQuery")]
+        CategoryQuery,
     }
 }


### PR DESCRIPTION
The saga continues. I've encountered the following error:
`Geo.Here.Models.Exceptions.HereException: Failed to parse the Here response properly. See the inner exception for more information.
 ---> Newtonsoft.Json.JsonSerializationException: Error converting value "postalCodePoint" to type 'Geo.Here.Enums.ResultType'. Path 'items[0].resultType', line 1, position 158.
 ---> System.ArgumentException: Requested value 'postalCodePoint' was not found.`


The issue is due to the fact that there appears to be 4 valid response values not captured in the ResultType enum. I have added them in accordance with this document:
https://developer.here.com/documentation/geocoding-search-api/dev_guide/topics/result-types.html

